### PR TITLE
Corrections according to the latest Desktop Entry Specification

### DIFF
--- a/Linux/gui/AESCrypt.desktop.in
+++ b/Linux/gui/AESCrypt.desktop.in
@@ -1,12 +1,8 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=AESCrypt
-Tooltip=Encrypt or Decrypt a file using AESCrypt 
 Comment=Encrypt or Decrypt a file using AESCrypt
 Exec=@bindir@/aescrypt-gui %f
-ExecutionMode=normal
 Type=Application
 Icon=@iconsdir@/SmallLock.png
 Categories=Application;Utility;TextEditor;
-MimeType=all/allfiles;
-Enabled=true
+MimeType=application/octet-stream;


### PR DESCRIPTION
- see: https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
- 'all' is an invalid MIME Type